### PR TITLE
Jazzy service subscribe fixes

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,95 @@
+# UFR fork of `rws` — differences from upstream
+
+This is Universal Field Robots' fork of [`v-kiniv/rws`](https://github.com/v-kiniv/rws).
+This file records how our `jazzy` line differs from upstream `jazzy`, so anyone
+vendoring it (currently `xs040_ws` and `lh209l_ws`, both under `src/rws`) knows
+what they're getting and why.
+
+Both lines descend from upstream `fa93e85`. **Ours** = `fa93e85` + org `jazzy-patch`
+(PR #5) + the fixes below. **Upstream `jazzy`** has moved on with its own commits.
+We do **not** track upstream wholesale — we cherry-pick.
+
+---
+
+## Changes only in our fork
+
+### Transport / server (`src/server_node.cpp`)
+- **permessage-deflate** WebSocket compression (`deflate_server_config`). Upstream has none — large messages to the GUI are compressed.
+- **TCP no-delay** (`set_tcp_pre_init_handler`, Nagle off) and **listen backlog 128** — lower latency, more pending connections.
+- **`nlohmann::ordered_json`** everywhere (upstream uses `nlohmann::json`) — preserves field order in responses.
+- **Safer locking** — `connection_lock_` is held across all `process_messages` branches, with `if (cd)` null-guards; `ping_all_clients` takes the lock and skips expired handles.
+
+### Typesupport (`src/typesupport_helpers.cpp`, `include/rws/generic_client.hpp`)
+- **`*_msgs` library fallback** — `get_typesupport_library_path` and
+  `get_service_typesupport_handle` try `pkg__…` then `pkg_msgs__…`, and
+  `generic_client` routes service typesupport through `rws::get_typesupport_library`.
+  Upstream uses stock `rclcpp::get_typesupport_library` with no fallback. **This is
+  what lets our `*_msgs` services resolve** (e.g. `ufr2_msgs/srv/*`, `automine_msgs/srv/*`).
+
+### Wire format for the GUI (`src/translate.cpp`)
+- **UUID `uint8[]` as a map** — serialized by iterating the JSON value
+  (`{"0":..,"1":..}`), because our GUI sends/expects that shape. **Do not revert** —
+  the GUI depends on it. (Trade-off: a fixed-size `T[N]` is emitted with
+  `field.size()` elements, so it relies on the GUI always sending the full length.)
+- **`secs`/`nsecs` timestamp field mapping**, both directions, to match roslibjs.
+  Upstream uses singular `nsec`.
+- Empty message arrays emit `[]` explicitly.
+
+### Connector (`include/rws/connector.hpp`)
+- **`subscribers_mutex_` held in `topic_message_callback`** — upstream removed this
+  lock (it iterates `subscribers_` unlocked, racing subscribe/unsubscribe). We keep it.
+- Latched-topic replay for a late subscriber reusing a shared subscription (the
+  one-shot helper subscription) — see "Known issues".
+
+---
+
+## Fixes on branch `jazzy-service-subscribe-fixes` (commit `04d9aa0`)
+
+Targeted at the two problems the GUI hit. Builds clean on Jazzy
+(`colcon build --merge-install --packages-select rws`).
+
+- **External service calls never hang** (`call_external_service`). The service type
+  is now resolved from the **ROS graph** (a generic client must use the real
+  advertised type, not the client's ROS1-style hint). Every failure path now sends a
+  `service_response` so the GUI always gets a reply; the async response callback is
+  wrapped in try/catch (it runs on an executor thread); `wait_for_service` is bounded
+  so a down service can't block the single processing thread. Upstream has **not**
+  fixed this — its `call_external_service` is still the pristine original.
+- **Subscribe before the publisher exists** (`subscribe_to_topic`). If a topic isn't
+  on the graph yet but the client supplies a `type`, we subscribe anyway (rosbridge
+  subscribe-ahead semantics) so it starts delivering once a publisher appears; the
+  genuine no-type error is throttled. A repeated subscribe is also acknowledged.
+  (Upstream `b451caa` fixes the same class differently — prefers the client type and
+  validates it against the graph.)
+
+---
+
+## What upstream has that we deliberately have **not** taken
+
+- **No-publisher QoS fallback** (best-effort/volatile when no publisher; otherwise
+  match all publishers). Not adopted — it's wrong for transient-local topics. We
+  intend to drive subscription QoS from the GUI instead (planned, see below).
+- Upstream's removal of the one-shot latched replay, its plain `nlohmann::json`, and
+  its nicer typesupport error strings.
+
+## Known issues / planned (not yet implemented)
+
+- **Typesupport library-cache data race** — `get_typesupport_library` reads
+  `g_shared_libs_` outside the lock; UB under the MultiThreadedExecutor. Present
+  upstream too. *Planned: lock the whole function.*
+- **Client-specified subscription QoS** (reliability + durability) plumbed through
+  `topic_params` → connector. *Planned — the deterministic replacement for upstream's
+  QoS heuristic.*
+- **`subscribe`/`advertise` should always respond** — a bad client-supplied type
+  currently throws and the client gets no reply (same hang class as the service fix).
+  *Planned: try/catch + error response.*
+- **`DROP` branch null-deref** in `process_messages` (`cd->is_alive` with no guard).
+  *Planned: add `if (cd)`.*
+- **Latched one-shot replay** (`connector.hpp`) uses a detached thread that
+  `future.wait()`s forever if nothing is latched — can leak in the rare multi-client
+  late-join case. *Planned: make the one-shot owned by the subscriber handle (no
+  thread, no timeout), paired with the client-QoS work.*
+
+A single GUI refresh drops all subscriptions and re-subscribes, which always creates
+fresh transient-local subscriptions — latched values come straight from DDS on that
+path, so refresh is unaffected by the one-shot.

--- a/FORK.md
+++ b/FORK.md
@@ -38,8 +38,15 @@ We do **not** track upstream wholesale — we cherry-pick.
 ### Connector (`include/rws/connector.hpp`)
 - **`subscribers_mutex_` held in `topic_message_callback`** — upstream removed this
   lock (it iterates `subscribers_` unlocked, racing subscribe/unsubscribe). We keep it.
-- Latched-topic replay for a late subscriber reusing a shared subscription (the
-  one-shot helper subscription) — see "Known issues".
+- **Latched-topic replay (bounded one-shot)** — when a late subscriber reuses an
+  existing shared subscription it would miss the latched sample. We spin up a
+  temporary transient-local subscription that replays the latched value from DDS to
+  just that subscriber, then tear it down. The original blocked on `future.wait()`
+  forever (leaking the thread/subscription if nothing was ever latched); it now uses
+  a bounded `future.wait_for(2s)` — long enough for DDS to deliver an existing
+  latched sample, after which the temp subscription is reset. The "subscribe before
+  the publisher exists" case is handled by the shared subscription's fan-out, not by
+  this one-shot. (Upstream removed this replay entirely.)
 
 ---
 
@@ -85,10 +92,6 @@ Targeted at the two problems the GUI hit. Builds clean on Jazzy
   *Planned: try/catch + error response.*
 - **`DROP` branch null-deref** in `process_messages` (`cd->is_alive` with no guard).
   *Planned: add `if (cd)`.*
-- **Latched one-shot replay** (`connector.hpp`) uses a detached thread that
-  `future.wait()`s forever if nothing is latched — can leak in the rare multi-client
-  late-join case. *Planned: make the one-shot owned by the subscriber handle (no
-  thread, no timeout), paired with the client-QoS work.*
 
 A single GUI refresh drops all subscriptions and re-subscribes, which always creates
 fresh transient-local subscriptions — latched values come straight from DDS on that

--- a/include/rws/connector.hpp
+++ b/include/rws/connector.hpp
@@ -100,7 +100,13 @@ public:
               },
               params, std::placeholders::_1));
 
-          future.wait();
+          // Wait for the latched sample, then tear the temporary subscription
+          // down. A real latched sample is delivered almost immediately on QoS
+          // match, so a bounded wait is enough; if nothing arrives there is
+          // nothing latched and we must not block/leak this thread forever (the
+          // "subscribe before the publisher exists" case is covered by the shared
+          // subscription's fan-out, not by this one-shot).
+          future.wait_for(std::chrono::seconds(2));
           oneshot_sub.reset();
         }).detach();
       }

--- a/src/client_handler.cpp
+++ b/src/client_handler.cpp
@@ -183,13 +183,31 @@ bool ClientHandler::subscribe_to_topic(const json & msg, json & response)
 
   std::string topic = msg["topic"];
   std::map<std::string, std::vector<std::string>> topics = node_->get_topic_names_and_types();
-  if (topics.find(topic) == topics.end()) {
-    response["error"] = "Topic " + topic + " not found";
+
+  std::string sub_type;
+  auto topic_it = topics.find(topic);
+  if (topic_it != topics.end() && !topic_it->second.empty()) {
+    // Type discovered from the live ROS graph.
+    sub_type = topic_it->second[0];
+  } else if (msg.contains("type") && msg["type"].is_string()) {
+    // Topic has no publisher yet. Rosbridge clients may subscribe ahead of the
+    // publisher by supplying the message type; honour it so the subscription
+    // starts delivering once a publisher appears. This also stops clients that
+    // periodically retry the subscription from spamming the log with errors.
+    sub_type = rws::message_type_to_ros2_style(msg["type"]);
+    RCLCPP_INFO(
+      get_logger(), "Topic '%s' not yet advertised; subscribing with provided type '%s'",
+      topic.c_str(), sub_type.c_str());
+  } else {
+    static rclcpp::Clock throttle_clock(RCL_STEADY_TIME);
+    response["error"] = "Topic " + topic + " not found and no type provided";
     response["result"] = false;
-    RCLCPP_ERROR(
-      get_logger(), "Failed to subscribe to topic: %s", response["error"].dump().c_str());
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), throttle_clock, 5000, "Failed to subscribe to topic: %s",
+      response["error"].dump().c_str());
     return true;
   }
+
   size_t history_depth = 10;
   if (msg.contains("history_depth") && msg["history_depth"].is_number()) {
     history_depth = msg["history_depth"];
@@ -204,16 +222,16 @@ bool ClientHandler::subscribe_to_topic(const json & msg, json & response)
   std::string compression =
     (!msg.contains("compression") || !msg["compression"].is_string()) ? "none" : msg["compression"];
 
-  auto sub_type = topics[topic][0];
   if (subscriptions_.count(topic) == 0) {
-    
     topic_params params(topic, sub_type, history_depth, compression, throttle_rate);
     subscriptions_[topic] = connector_->subscribe_to_topic(
       client_id_, params, std::bind(&ClientHandler::subscription_callback, this, std::placeholders::_1, std::placeholders::_2));
-
-    response["type"] = sub_type;
-    response["result"] = true;
   }
+
+  // Always acknowledge, even if the subscription already existed, so the client
+  // isn't left waiting for a response on a repeated subscribe.
+  response["type"] = sub_type;
+  response["result"] = true;
 
   return true;
 }
@@ -471,46 +489,81 @@ bool ClientHandler::call_service(const json & msg, json & response)
 bool ClientHandler::call_external_service(const json & msg, json & response)
 {
   std::string service_name = msg["service"];
-  std::string service_type = msg["type"];
 
+  response["op"] = "service_response";
+  response["service"] = service_name;
+  response["result"] = false;
+
+  // A generic client must be built from the service type that is actually
+  // advertised on the ROS graph (e.g. "automine_msgs/srv/GetRobotDescription").
+  // The type a rosbridge client sends (if any) is a ROS1-style hint (e.g.
+  // "automine_msgs/GetRobotDescription") whose package layout doesn't match the
+  // ROS2 typesupport library, so it can't be used to look up typesupport.
+  // Resolving from the graph is therefore both more correct and the only thing
+  // that reliably works.
   std::map<std::string, std::vector<std::string>> services = node_->get_service_names_and_types();
-  if (services.find(service_name) == services.end()) {
-    RCLCPP_ERROR(get_logger(), "Service not found: %s", service_name.c_str());
-    return false;
+  auto svc_it = services.find(service_name);
+  if (svc_it == services.end() || svc_it->second.empty()) {
+    response["error"] = "Service " + service_name + " not available";
+    RCLCPP_ERROR(get_logger(), "%s", response["error"].get<std::string>().c_str());
+    // Return handled so the (failed) response is sent back; otherwise the client
+    // waits forever for a reply that never comes.
+    return true;
   }
+  std::string service_type = svc_it->second[0];
 
-  if (clients_.count(service_name) == 0) {
-    clients_[service_name] = node_->create_generic_client(
-      service_name, service_type, rmw_qos_profile_services_default, nullptr);
-  }
-
-  while (!clients_[service_name]->wait_for_service(1s)) {
-    if (!rclcpp::ok()) {
-      RCLCPP_ERROR(get_logger(), "Interrupted while waiting for the service. Exiting.");
-      response["result"] = false;
-      return false;
+  try {
+    if (clients_.count(service_name) == 0) {
+      clients_[service_name] = node_->create_generic_client(
+        service_name, service_type, rmw_qos_profile_services_default, nullptr);
     }
-    RCLCPP_INFO(get_logger(), "service not available, waiting again...");
+
+    // The service is on the graph, so it should become ready almost immediately.
+    // Bound the wait so a momentarily-unavailable service can't block the single
+    // message-processing thread (and therefore every other client) indefinitely.
+    if (!clients_[service_name]->wait_for_service(5s)) {
+      response["error"] = "Service " + service_name + " did not become ready";
+      RCLCPP_ERROR(get_logger(), "%s", response["error"].get<std::string>().c_str());
+      return true;
+    }
+
+    const json & args = msg.contains("args") ? msg["args"] : json::object();
+    auto serialized_req = json_to_serialized_service_request(service_type, args);
+
+    using ServiceResponseFuture = rws::GenericClient::SharedFuture;
+    auto response_received_callback = [this, id = msg.value("id", json()), service_name,
+                                       service_type](ServiceResponseFuture future) {
+      // This runs on an executor thread; an uncaught exception here would tear
+      // down the executor, so translate failures into an error response instead.
+      json m = {
+        {"id", id},
+        {"op", "service_response"},
+        {"service", service_name},
+      };
+      try {
+        m["values"] = serialized_service_response_to_json(service_type, future.get());
+        m["result"] = true;
+      } catch (const std::exception & e) {
+        m["result"] = false;
+        m["error"] = std::string("Failed to deserialize service response: ") + e.what();
+        RCLCPP_ERROR(get_logger(), "%s", m["error"].get<std::string>().c_str());
+      }
+      std::string json_str = m.dump();
+      this->send_message(json_str);
+    };
+    clients_[service_name]->async_send_request(serialized_req, response_received_callback);
+  } catch (const std::exception & e) {
+    // Drop a possibly half-initialised client so a later call can rebuild it.
+    clients_.erase(service_name);
+    response["error"] = std::string("Failed to call service ") + service_name + ": " + e.what();
+    RCLCPP_ERROR(get_logger(), "%s", response["error"].get<std::string>().c_str());
+    return true;
   }
 
-  auto serialized_req = json_to_serialized_service_request(service_type, msg["args"]);
-  using ServiceResponseFuture = rws::GenericClient::SharedFuture;
-  auto response_received_callback = [this, id = msg["id"], service_name,
-                                     service_type](ServiceResponseFuture future) {
-    json response_json = serialized_service_response_to_json(service_type, future.get());
-    json m = {
-      {"id", id},
-      {"op", "service_response"},
-      {"service", service_name},
-      {"values", response_json},
-      {"result", true},
-    };
-
-    std::string json_str = m.dump();
-    this->send_message(json_str);
-  };
-  clients_[service_name]->async_send_request(serialized_req, response_received_callback);
-
+  // Request dispatched successfully. Acknowledge synchronously; the real result
+  // is delivered asynchronously from response_received_callback once the service
+  // replies. (op "call_service" so the client doesn't mistake this ack for the
+  // actual "service_response".)
   response["op"] = "call_service";
   response["result"] = true;
   return true;


### PR DESCRIPTION
# Targeted fixes: external service calls and late subscribe

## Overview
This PR adds two critical fixes to the jazzy branch addressing issues encountered by the GUI:
1. External service calls no longer hang indefinitely
2. Subscribe before publisher exists now works correctly

Includes comprehensive documentation of UFR fork divergences from upstream in `FORK.md`.

## Problem Statements

### 1. Service Call Hangs (GUI Blocking)
**Problem**: `call_external_service` could block indefinitely, freezing the entire server since it processes messages on a single thread. This happened when:
- A service wasn't ready yet (waiting forever for `wait_for_service`)
- Any exception during async callback processing could crash the executor
- No response was ever sent to the client if something failed

**Root Cause**: The original code used an unbounded `wait_for_service(1s)` loop that would retry infinitely, with no timeout on the overall operation.

### 2. Subscribe Before Publisher Exists (GUI Can't Discover Topics)
**Problem**: If a client tried to subscribe to a topic that hadn't been advertised yet, the subscription would fail immediately with "Topic not found", even though the GUI was providing the message type hint. This prevented subscriptions from starting when:
- Topic is published by a component starting after the GUI connection
- GUI refreshes and re-subscribes while the publisher briefly vanishes

**Root Cause**: The code rejected any topic without an active publisher on the ROS graph, ignoring the client-provided type hint.

## Changes

### Service Call Fixes (`call_external_service`)

1. **Resolve service type from ROS graph** (not from client hint)
   - A generic client requires the actual advertised ROS2 service type (e.g., `automine_msgs/srv/GetRobotDescription`)
   - Client hints use ROS1 style (e.g., `automine_msgs/GetRobotDescription`) which don't match typesupport library layouts
   - Fetching from the graph is both more correct and the only reliable way to work

2. **Bounded wait for service availability** (5 seconds)
   - Service should be ready almost immediately if it's on the graph
   - Prevents blocking the single message-processing thread indefinitely
   - If service doesn't come ready, sends error response instead of hanging

3. **Always send response to client**
   - Every failure path now returns `service_response` so the GUI never hangs waiting for a reply
   - Service not available → error response (handled, return `true`)
   - Service not ready → error response with timeout (handled, return `true`)
   - Async callback wrapped in try/catch so exceptions become error responses instead of executor crashes
   - Normal path also acknowledges with `call_service` op before async response, so client knows we received it

4. **Improved error handling**
   - Wrap entire service call in try/catch
   - Delete half-initialized clients so they can be rebuilt on retry
   - All errors are logged and sent to client with descriptive messages

### Subscribe Fixes (`subscribe_to_topic`)

1. **Subscribe-ahead semantics: rosbridge compatibility**
   - If topic isn't on the graph but client supplies a type, subscribe anyway with that type
   - Once a publisher appears for that topic, the subscription will start delivering
   - Client can retry subscribe without getting errors (uses throttled logging)

2. **Type discovery priority**
   - Prefer live type from ROS graph (most authoritative)
   - Fall back to client-supplied type if topic has no publisher yet
   - Error only if neither exists and client didn't provide a type

3. **Always acknowledge subscription**
   - Even if subscription already existed, send response to client
   - Prevents client from waiting indefinitely on repeated subscribe attempts
   - Sets `response["type"]` and `response["result"]` for both new and existing subscriptions

### Connector Fix (`connector.hpp`)

**Latched topic replay timeout** (bounded one-shot)
- Changed `future.wait()` → `future.wait_for(std::chrono::seconds(2))`
- Prevents thread leak if no latched sample ever arrives
- 2-second window is sufficient for DDS to deliver an existing latched value
- If nothing latched, falls back to the shared subscription's fan-out mechanism

### Documentation

**New file**: `FORK.md`
- Documents all UFR fork differences from upstream v-kiniv/rws
- Lists transport/server enhancements (permessage-deflate, TCP no-delay, ordered_json)
- Explains typesupport `*_msgs` fallback (why our services work)
- Details wire format changes for the GUI (UUID/timestamp mapping)
- Records known issues and planned improvements

## Files Modified
- `FORK.md` — New documentation file (comprehensive fork divergence guide)
- `src/client_handler.cpp` — Service call and subscribe fixes
- `include/rws/connector.hpp` — Bounded latched-topic one-shot timeout

## Impact

### Reliability
- No more indefinite hangs on external service calls
- Single message-processing thread is protected from blocking
- GUI can discover and subscribe to topics that start after connection

### Compatibility
- Upstream has **not** fixed `call_external_service` (still pristine/broken)
- Subscribe-ahead is different from upstream's approach but achieves similar goal
- Documented in `FORK.md` for future maintainers

### Testing Notes
- Fixes GUI hang when calling services (e.g., GetRobotDescription)
- Fixes GUI hang when discovering topics on late-starting components
- Service call timeout is 5 seconds (configurable if needed)
- Latched topic one-shot now completes in ≤2 seconds instead of leaking threads

## Commits Summary
This PR is structured as targeted fixes on top of jazzy that address specific GUI issues without wholesale re-merging upstream, keeping the fork maintainable and traceable.